### PR TITLE
This combines createListing and updateListing

### DIFF
--- a/contracts/TreasureMarketplace.sol
+++ b/contracts/TreasureMarketplace.sol
@@ -115,6 +115,7 @@ contract TreasureMarketplace is OwnableUpgradeable, PausableUpgradeable, Reentra
         uint256 _expirationTime
     )
         external
+        nonReentrant
         whenNotPaused
     {
         require(listings[_nftAddress][_tokenId][_msgSender()].quantity == 0, "already listed");

--- a/test/TreasureMarketplace.test.ts
+++ b/test/TreasureMarketplace.test.ts
@@ -214,13 +214,14 @@ describe('TreasureMarketplace', function () {
 
           await marketplace.unpause();
 
-          await expect(marketplace.connect(sellerSigner).updateListing(
+          // Can increase price
+          marketplace.connect(sellerSigner).updateListing(
               nft.address,
               tokenId,
               1,
               pricePerItem.add(1),
               newExpirationTime
-          )).to.be.revertedWith("Cannot increase price")
+          );
 
           await marketplace.connect(sellerSigner).updateListing(
               nft.address,
@@ -244,7 +245,7 @@ describe('TreasureMarketplace', function () {
               0,
               newPricePerItem,
               newExpirationTime
-          )).to.be.revertedWith("Cannot list multiple ERC721");
+          )).to.be.revertedWith("cannot list multiple ERC721");
 
           const listing = await marketplace.listings(nft.address, tokenId, seller);
           expect(listing.quantity).to.be.equal(1);
@@ -522,7 +523,7 @@ describe('TreasureMarketplace', function () {
               0,
               newPricePerItem,
               newExpirationTime
-          )).to.be.revertedWith("cannot update quantity to 0");
+          )).to.be.revertedWith("nothing to list");
 
           await expect(marketplace.connect(sellerSigner).updateListing(
               erc1155.address,
@@ -532,13 +533,14 @@ describe('TreasureMarketplace', function () {
               newExpirationTime
           )).to.be.revertedWith("cannot sell for 0");
 
-          await expect(marketplace.connect(sellerSigner).updateListing(
+          // Can increase price
+          marketplace.connect(sellerSigner).updateListing(
               erc1155.address,
               tokenId,
               newQuantity,
               pricePerItem.add(1),
               newExpirationTime
-          )).to.be.revertedWith("Cannot increase price");
+          );
 
           await marketplace.connect(sellerSigner).updateListing(
               erc1155.address,


### PR DESCRIPTION
Fixes #17, fixes #18

Notes that affect the application:

1. Previously, the contract had an undocumented feature where existing listings could not be updated to increase the price. This PR removes that limitation. (As noted in documentation, this does not create a front-running risk because the buyer will always specify a price.)
2. The `updateListing` function is removed, just use `createListing` wherever you would have used `updateListing`.
3. The `ItemUpdated` event is removed. Instead, you will now see `ItemListed` events. If you had previously been relying on the count of `ItemListed` events for some reason and you believe this change hurts you, please let's discuss further.